### PR TITLE
Bump GHIDRA version to 10.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["10.0.4" ]
+        ghidra: ["10.1.1" ]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Just needs the following commands for a new release after merging:

```
git pull
git checkout master
git tag -a 1.5.0 -m "Ghidra Switch Loader 1.5.0 (10.1.1)"
git push origin 1.5.0
```

For review help:
* [CI tested here](https://github.com/jam1garner/Ghidra-Switch-Loader/runs/4664409301?check_suite_focus=true)
* [Resulting release/binary produced here](https://github.com/jam1garner/Ghidra-Switch-Loader/releases/tag/1.5.0)