### PR TITLE
Add support for 17.0.0 (64-bit only)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@
 // application.gradle.version property in <GHIDRA_INSTALL_DIR>/Ghidra/application.properties
 // for the correction version of Gradle to use for the Ghidra installation you specify.
 
-import org.apache.tools.ant.filters.ReplaceTokens
-
 //----------------------START "DO NOT MODIFY" SECTION------------------------------
+apply plugin: 'java'
+apply plugin: 'eclipse'
 def ghidraInstallDir
 
 if (System.env.GHIDRA_INSTALL_DIR) {
@@ -33,9 +33,6 @@ else {
     throw new GradleException("GHIDRA_INSTALL_DIR is not defined!")
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
-
-def DISTRIBUTION_DIR = file("dist")
-def PATH_IN_ZIP = "${project.name}"
 
 def getGitHash = {
     def stdout = new ByteArrayOutputStream()
@@ -58,68 +55,58 @@ configurations {
     localDeps
 }
 
+def docs = file(ghidraInstallDir+'/docs/GhidraAPI_javadoc.zip')
+def ghidraUserDir = System.getProperty("user.home") + "/.ghidra/.${DISTRO_PREFIX}_${RELEASE_NAME}"
+
 dependencies {
-    api fileTree(dir: ghidraInstallDir + '/Ghidra/Processors', include: "**/*.jar")
     implementation 'commons-primitives:commons-primitives:1.0'
     localDeps group: 'org.lz4', name: 'lz4-java', version: '1.5.1'
     api configurations.localDeps
+
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/patch', include: "**/*.jar")
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Configurations', include: "**/*.jar")
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Features', include: "**/*.jar")
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Framework', include: "**/*.jar")
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Processors', include: "**/*.jar")
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Debug', include: "**/*.jar")
+    runtimeOnly fileTree(dir: ghidraInstallDir + '/Ghidra/Extensions',
+            include: "**/*.jar", exclude: project.name)
+    runtimeOnly fileTree(dir: ghidraUserDir + "/Extensions",
+            include: "**/*.jar", exclude: project.name)
 }
 
-buildExtension.enabled = false
-defaultTasks 'createDistribution'
+eclipse {
+    classpath {
+        downloadJavadoc = true
+        downloadSources = true
+        file {
+            whenMerged {
+                for (entry in entries) {
+                    if (entry.path.contains('jar')) {
+                        File folder = new File(entry.getPath()).getParentFile();
+                        for (File file : folder.listFiles()) {
+                            if (file.getName().endsWith(".zip")) {
+                                if (file.getName().contains("-src")) {
+                                    entry.setSourcePath(it.fileReference(file));
+                                }
+                                entry.setJavadocPath(it.fileReference(docs));
+                            }
+                        }
+                    }
+                }
+                entries.add(
+                        new org.gradle.plugins.ide.eclipse.model.Library(
+                                it.fileReference(new File(projectDir, '/data'))
+                        )
+                )
+            }
+        }
+    }
+}
 
-task createDistribution (type: Zip) {
+buildExtension {
+    exclude 'gradle*'
+    exclude '.github/**'
+
     archiveBaseName = "${project.name}-${project.version}-${getGitHash()}-Ghidra_${ghidra_version}".replace(' ', '_')
-    archiveExtension = 'zip'
-    destinationDirectory = DISTRIBUTION_DIR
-    version ''
-
-    // Make sure that we don't try to copy the same file with the same path into the
-    // zip (this can happen!)
-    duplicatesStrategy 'exclude'
-
-    // This filtered property file copy must appear before the general 
-    // copy to ensure that it is prefered over the unmodified file
-    File propFile = new File(project.projectDir, "extension.properties")
-    from (propFile) {
-        String version = "${ghidra_version}"
-        String name = "${project.name}"
-        filter (ReplaceTokens, tokens: [extversion: version])
-        filter (ReplaceTokens, tokens: [extname: name])
-        into PATH_IN_ZIP
-    }
-
-    from (project.jar) {
-        into PATH_IN_ZIP + "/lib"
-    }
-
-    // Copy lz4 and any other dependencies that only we rely on
-    from (configurations.localDeps) {
-        into PATH_IN_ZIP + "/lib"
-    }
-
-    from (project.projectDir) {
-        exclude 'build/**'
-        exclude '*.gradle'
-        exclude 'certification.manifest'
-        exclude 'dist/**'
-        exclude 'bin/**'
-        exclude 'src/**'
-        exclude '.gradle/**'
-        exclude 'gradle/**'
-        exclude 'gradlew'
-        exclude 'gradlew.bat'
-        exclude '.classpath'
-        exclude '.project'
-        exclude '.settings/**'
-        exclude 'developer_scripts'
-        exclude '.antProperties.xml'
-        exclude 'eclipse/**'
-
-        into PATH_IN_ZIP
-    }
-
-    doLast {
-        println "\nCreated " + baseName + "." + extension + " in " + destinationDir
-    }
 }

--- a/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
+++ b/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
@@ -341,7 +341,7 @@ public class IPCAnalyzer extends AbstractAnalyzer
         
         try
         {
-            for (long off = text.getStart().getOffset(); off < text.getEnd().getOffset(); off += 0x4)
+            for (long off = text.getStart().getOffset(); off < text.getEnd().getOffset() - 0x4; off += 0x4)
             {
                 long val1 = (elfProvider.getReader().readUnsignedInt(off) & 0xFFFFFF00L) >> 8;
                 long val2 = (elfProvider.getReader().readUnsignedInt(off + 0x4) & 0xFFFFFF00L) >> 8;

--- a/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
+++ b/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
@@ -6,23 +6,14 @@
  */
 package adubbz.nx.analyzer;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import org.apache.commons.compress.utils.Lists;
-import org.python.google.common.collect.HashBiMap;
-import org.python.google.common.collect.Sets;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Multimap;
-
 import adubbz.nx.analyzer.ipc.IPCEmulator;
 import adubbz.nx.analyzer.ipc.IPCTrace;
 import adubbz.nx.common.ElfCompatibilityProvider;
 import adubbz.nx.common.NXRelocation;
 import adubbz.nx.loader.SwitchLoader;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
 import generic.stl.Pair;
 import ghidra.app.services.AbstractAnalyzer;
 import ghidra.app.services.AnalyzerType;
@@ -47,9 +38,17 @@ import ghidra.program.model.symbol.Symbol;
 import ghidra.program.model.symbol.SymbolTable;
 import ghidra.program.model.util.CodeUnitInsertionException;
 import ghidra.util.Msg;
-import ghidra.util.exception.CancelledException;
 import ghidra.util.exception.InvalidInputException;
 import ghidra.util.task.TaskMonitor;
+import org.apache.commons.compress.utils.Lists;
+import org.python.google.common.collect.HashBiMap;
+import org.python.google.common.collect.Sets;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static adubbz.nx.common.ElfCompatibilityProvider.R_FAKE_RELR;
 
 public class IPCAnalyzer extends AbstractAnalyzer 
 {
@@ -311,8 +310,7 @@ public class IPCAnalyzer extends AbstractAnalyzer
         return out;
     }
     
-    protected HashBiMap<Address, Address> locateSTables(Program program, ElfCompatibilityProvider elfProvider)
-    {
+    protected HashBiMap<Address, Address> locateSTables(Program program, ElfCompatibilityProvider elfProvider) throws MemoryAccessException {
         HashBiMap<Address, Address> out = HashBiMap.create();
         List<Pair<Long, Long>> candidates = new ArrayList<>();
         AddressSpace aSpace = program.getAddressFactory().getDefaultAddressSpace();
@@ -321,8 +319,13 @@ public class IPCAnalyzer extends AbstractAnalyzer
         
         for (NXRelocation reloc : elfProvider.getRelocations()) 
         {
-            if (reloc.addend > 0)
+            if (reloc.addend > 0) {
                 candidates.add(new Pair<>(baseAddr.getOffset() + reloc.addend, baseAddr.getOffset() + reloc.offset));
+            }
+            else if (reloc.r_type == R_FAKE_RELR) {
+                reloc.addend = mem.getLong(baseAddr.add(reloc.offset)) - baseAddr.getOffset();
+                candidates.add(new Pair<>(baseAddr.getOffset() + reloc.addend, baseAddr.getOffset() + reloc.offset));
+            }
         }
         
         candidates.sort(Comparator.comparing(a -> a.first));
@@ -675,8 +678,7 @@ public class IPCAnalyzer extends AbstractAnalyzer
     /**
      * A map of relocated entries in the global offset table to their new values.
      */
-    protected Map<Address, Address> getGotDataSyms(Program program, ElfCompatibilityProvider elfProvider)
-    {
+    protected Map<Address, Address> getGotDataSyms(Program program, ElfCompatibilityProvider elfProvider) throws MemoryAccessException {
         if (gotDataSyms != null)
             return this.gotDataSyms;
         
@@ -686,6 +688,10 @@ public class IPCAnalyzer extends AbstractAnalyzer
         for (NXRelocation reloc : elfProvider.getRelocations()) 
         {
             long off;
+
+            if (reloc.r_type == R_FAKE_RELR) {
+                reloc.addend = program.getMemory().getLong(baseAddr.add(reloc.offset)) - baseAddr.getOffset();
+            }
             
             if (reloc.sym != null && reloc.sym.getSectionHeaderIndex() != ElfSectionHeaderConstants.SHN_UNDEF && reloc.sym.getValue() == 0)
             {

--- a/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
+++ b/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
@@ -684,9 +684,15 @@ public class IPCAnalyzer extends AbstractAnalyzer
         
         Address baseAddr = program.getImageBase();
         gotDataSyms = new HashMap<>();
+        MemoryBlock gotBlock = program.getMemory().getBlock(".got");
         
         for (NXRelocation reloc : elfProvider.getRelocations()) 
         {
+            if (baseAddr.add(reloc.offset).getOffset() < gotBlock.getStart().getOffset() || baseAddr.add(reloc.offset).getOffset() > gotBlock.getEnd().getOffset() + 1)
+            {
+                continue;
+            }
+
             long off;
 
             if (reloc.r_type == R_FAKE_RELR) {

--- a/src/main/java/adubbz/nx/loader/nxo/MOD0Adapter.java
+++ b/src/main/java/adubbz/nx/loader/nxo/MOD0Adapter.java
@@ -127,7 +127,7 @@ public abstract class MOD0Adapter extends NXOAdapter
         boolean good = false;
         List<Long> relocationOffsets = this.getRelocations(program).stream().map(reloc -> reloc.offset).toList();
         MemoryBlock gotPlt = this.program.getMemory().getBlock(".got.plt");
-        long gotStart = gotPlt != null ? gotPlt.getEnd().getOffset() : this.getDynamicOffset() + this.getDynamicSize();
+        long gotStart = gotPlt != null ? gotPlt.getEnd().getOffset() + 1 - this.program.getImageBase().getOffset() : this.getDynamicOffset() + this.getDynamicSize();
         long gotEnd = gotStart + this.getOffsetSize();
         long initArrayValue;
 
@@ -149,6 +149,7 @@ public abstract class MOD0Adapter extends NXOAdapter
             return true;
         }
 
+        Msg.error(this, "Failed to find .got section.");
         return false;
     }
     

--- a/src/main/java/adubbz/nx/loader/nxo/MOD0Adapter.java
+++ b/src/main/java/adubbz/nx/loader/nxo/MOD0Adapter.java
@@ -6,21 +6,20 @@
  */
 package adubbz.nx.loader.nxo;
 
-import java.io.IOException;
-
 import adubbz.nx.common.ElfCompatibilityProvider;
 import adubbz.nx.common.InvalidMagicException;
-import adubbz.nx.common.NXRelocation;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.bin.format.elf.ElfDynamic;
-import ghidra.app.util.bin.format.elf.ElfDynamicTable;
 import ghidra.app.util.bin.format.elf.ElfDynamicType;
 import ghidra.app.util.bin.format.elf.ElfException;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.util.Msg;
 import ghidra.util.exception.NotFoundException;
+
+import java.io.IOException;
+import java.util.List;
 
 /*
  * An adapter implementation for binaries with a MOD0 section.
@@ -102,91 +101,74 @@ public abstract class MOD0Adapter extends NXOAdapter
         
         return mod0.getBssSize();
     }
+
+    private long gotOffset = 0;
+    private long gotSize = 0;
+
+    private boolean findGot() {
+        assert this.program != null;
+
+        if (this.gotOffset > 0 && this.gotSize > 0) {
+            return true;
+        }
+
+        MOD0Header mod0 = this.getMOD0();
+
+        if (mod0 == null) {
+            return false;
+        }
+
+        if (mod0.hasLibnxExtension()) {
+            this.gotOffset = mod0.getLibnxGotStart() + this.program.getImageBase().getOffset();
+            this.gotSize = mod0.getLibnxGotEnd() - mod0.getLibnxGotStart();
+            return true;
+        }
+
+        boolean good = false;
+        List<Long> relocationOffsets = this.getRelocations(program).stream().map(reloc -> reloc.offset).toList();
+        MemoryBlock gotPlt = this.program.getMemory().getBlock(".got.plt");
+        long gotStart = gotPlt != null ? gotPlt.getEnd().getOffset() : this.getDynamicOffset() + this.getDynamicSize();
+        long gotEnd = gotStart + this.getOffsetSize();
+        long initArrayValue;
+
+        try {
+            initArrayValue = this.getDynamicTable(program).getDynamicValue(ElfDynamicType.DT_INIT_ARRAY);
+        } catch (NotFoundException ignored) {
+            initArrayValue = -1;
+        }
+
+        while ((relocationOffsets.contains(gotEnd) || (gotPlt == null && initArrayValue != -1 && gotEnd < initArrayValue))
+                && (initArrayValue == -1 || gotEnd < initArrayValue || gotStart > initArrayValue)) {
+            good = true;
+            gotEnd += this.getOffsetSize();
+        }
+
+        if (good) {
+            this.gotOffset = this.program.getImageBase().getOffset() + gotStart;
+            this.gotSize = gotEnd - gotStart;
+            return true;
+        }
+
+        return false;
+    }
     
     @Override
     public long getGotOffset()
     {
-        MOD0Header mod0 = this.getMOD0();
-        
-        if (mod0 == null)
-            return 0;
-        
-        if (mod0.hasLibnxExtension())
-        {
-            return mod0.getLibnxGotStart() + this.program.getImageBase().getOffset();
+        if (this.findGot()) {
+            return this.gotOffset;
         }
-        
-        MemoryBlock gotPlt = this.program.getMemory().getBlock(".got.plt");
-        
-        if (gotPlt == null)
-            return 0;
-        
-        return gotPlt.getEnd().getOffset() + 1;
+
+        return 0;
     }
-    
-    private long gotSize = 0;
     
     @Override
     public long getGotSize()
     {
-        assert this.program != null;
-        
-        if (this.gotSize > 0)
-            return this.gotSize;
-        
-        MOD0Header mod0 = this.getMOD0();
-        
-        if (mod0 == null)
-            return 0;
-        
-        if (mod0.hasLibnxExtension())
-        {
-            this.gotSize = mod0.getLibnxGotEnd() - mod0.getLibnxGotStart();
+        if (this.findGot()) {
             return this.gotSize;
         }
-        
-        ElfDynamicTable dt = this.getDynamicTable(this.program);
-        long baseAddr = this.program.getImageBase().getOffset();
-        long gotEnd = this.getGotOffset() + this.getOffsetSize();
-        boolean good = false;
-        
-        if (dt == null || gotEnd == this.getOffsetSize())
-            return 0;
-        
-        try 
-        {
-            while (!dt.containsDynamicValue(ElfDynamicType.DT_INIT_ARRAY) || gotEnd < (baseAddr + dt.getDynamicValue(ElfDynamicType.DT_INIT_ARRAY)))
-            {
-                boolean foundOffset = false;
-                
-                for (NXRelocation reloc : this.getRelocations(this.program))
-                {
-                    if ((baseAddr + reloc.offset) == gotEnd)
-                    {
-                        foundOffset = true;
-                        break;
-                    }
-                }
-                
-                if (!foundOffset)
-                    break;
-                
-                good = true;
-                gotEnd += this.getOffsetSize();
-            }
-        } 
-        catch (NotFoundException e) 
-        {
-            Msg.error(this, "Failed to get got size", e);
-            return 0;
-        }
-        
-        if (good)
-        {
-            this.gotSize = gotEnd - this.getGotOffset();
-            return this.gotSize;
-        }
-        
+
         return 0;
     }
     


### PR DESCRIPTION
This PR adds support for read-only relocations which were added in 17.0.0 binaries.

These changes were ported from SciresM's changes to `nxo64.py`/`ipcserver.py` [here](https://github.com/SciresM/switch-reversing/tree/1700_support), which is why I added him as a co-author to these commits.

The nxo64 changes are already done, but I need to figure out how to port the ipcserver changes, since they involve  reading values from the `IPCEmulator` and I'm currently trying to understand how this could be done here. I currently think the emulator is set up in one function and only used there, which differs from the way ipcserver seems to handle it.

I'll mark this PR as draft until I either figure this out or somebody else figures it out before me and wants to add the solution here.

---

Aside from these changes I made a minor adjustment to the way plt entries are handled, so no exceptions can be thrown there and the user instead just receives a note about missing support for CFI-enabled binaries.

This closes #41, but doesn't solve the underlying issue that we currently can't find the plt for the binaries mentioned above. 