### PR TITLE
Fix compilation errors for 11.0.2+

### DIFF
--- a/src/main/java/adubbz/nx/common/ElfCompatibilityProvider.java
+++ b/src/main/java/adubbz/nx/common/ElfCompatibilityProvider.java
@@ -14,8 +14,8 @@ import ghidra.app.util.bin.ByteProvider;
 import ghidra.app.util.bin.format.elf.*;
 import ghidra.app.util.bin.format.elf.extend.ElfExtensionFactory;
 import ghidra.app.util.bin.format.elf.extend.ElfLoadAdapter;
-import ghidra.app.util.bin.format.elf.relocation.AARCH64_ElfRelocationConstants;
-import ghidra.app.util.bin.format.elf.relocation.ARM_ElfRelocationConstants;
+import ghidra.app.util.bin.format.elf.relocation.AARCH64_ElfRelocationType;
+import ghidra.app.util.bin.format.elf.relocation.ARM_ElfRelocationType;
 import ghidra.program.model.listing.Program;
 import ghidra.program.model.mem.MemoryBlock;
 import ghidra.util.Msg;
@@ -294,7 +294,7 @@ public class ElfCompatibilityProvider
                 sym = null;
             }
             
-            if (r_type != AARCH64_ElfRelocationConstants.R_AARCH64_TLSDESC && r_type != ARM_ElfRelocationConstants.R_ARM_TLS_DESC)
+            if (r_type != AARCH64_ElfRelocationType.R_AARCH64_TLSDESC.typeId() && r_type != ARM_ElfRelocationType.R_ARM_TLS_DESC.typeId())
             {
                 locations.add(offset);
             }

--- a/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java
+++ b/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java
@@ -22,8 +22,8 @@ import ghidra.app.util.bin.format.elf.ElfDynamicType;
 import ghidra.app.util.bin.format.elf.ElfSectionHeaderConstants;
 import ghidra.app.util.bin.format.elf.ElfStringTable;
 import ghidra.app.util.bin.format.elf.ElfSymbol;
-import ghidra.app.util.bin.format.elf.relocation.AARCH64_ElfRelocationConstants;
-import ghidra.app.util.bin.format.elf.relocation.ARM_ElfRelocationConstants;
+import ghidra.app.util.bin.format.elf.relocation.AARCH64_ElfRelocationType;
+import ghidra.app.util.bin.format.elf.relocation.ARM_ElfRelocationType;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.program.model.address.*;
 import ghidra.program.model.data.PointerDataType;
@@ -308,9 +308,9 @@ public class NXProgramBuilder
             Address target = this.aSpace.getAddress(reloc.offset + this.nxo.getBaseAddress());
             long originalValue = adapter.isAarch32() ? this.program.getMemory().getInt(target) : this.program.getMemory().getLong(target);
             
-            if (reloc.r_type == ARM_ElfRelocationConstants.R_ARM_GLOB_DAT ||
-                    reloc.r_type == ARM_ElfRelocationConstants.R_ARM_JUMP_SLOT ||
-                    reloc.r_type == ARM_ElfRelocationConstants.R_ARM_ABS32) 
+            if (reloc.r_type == ARM_ElfRelocationType.R_ARM_GLOB_DAT.typeId() ||
+                    reloc.r_type == ARM_ElfRelocationType.R_ARM_JUMP_SLOT.typeId() ||
+                    reloc.r_type == ARM_ElfRelocationType.R_ARM_ABS32.typeId()) 
                 {
                     if (reloc.sym == null) 
                     {
@@ -321,13 +321,13 @@ public class NXProgramBuilder
                         program.getMemory().setInt(target, (int)(reloc.sym.getValue() + this.nxo.getBaseAddress()));
                     }
                 } 
-            else if (reloc.r_type == ARM_ElfRelocationConstants.R_ARM_RELATIVE)
+            else if (reloc.r_type == ARM_ElfRelocationType.R_ARM_RELATIVE.typeId())
             {
                 program.getMemory().setInt(target, (int)(program.getMemory().getInt(target) + this.nxo.getBaseAddress()));
             }
-            else if (reloc.r_type == AARCH64_ElfRelocationConstants.R_AARCH64_GLOB_DAT ||
-                reloc.r_type == AARCH64_ElfRelocationConstants.R_AARCH64_JUMP_SLOT ||
-                reloc.r_type == AARCH64_ElfRelocationConstants.R_AARCH64_ABS64) 
+            else if (reloc.r_type == AARCH64_ElfRelocationType.R_AARCH64_GLOB_DAT.typeId() ||
+                reloc.r_type == AARCH64_ElfRelocationType.R_AARCH64_JUMP_SLOT.typeId() ||
+                reloc.r_type == AARCH64_ElfRelocationType.R_AARCH64_ABS64.typeId()) 
             {
                 if (reloc.sym == null) 
                 {
@@ -343,7 +343,7 @@ public class NXProgramBuilder
                         gotNameLookup.put(reloc.offset, reloc.sym.getNameAsString());
                 }
             } 
-            else if (reloc.r_type == AARCH64_ElfRelocationConstants.R_AARCH64_RELATIVE) 
+            else if (reloc.r_type == AARCH64_ElfRelocationType.R_AARCH64_RELATIVE.typeId()) 
             {
                 program.getMemory().setLong(target, this.nxo.getBaseAddress() + reloc.addend);
             }


### PR DESCRIPTION
Fixes errors caused by https://github.com/NationalSecurityAgency/ghidra/commit/3ead54f0acc46f77a21a6d6f40ed8b08d33968f7.

This is a slightly hacky fix (using `typeId()` everywhere instead of using the enum), but I don't see a nicer way without restructuring quite a lot because `r_type` here can be either an AARCH64 or ARM relocation type id.