### PR TITLE
Disassemble .plt section and mark functions as thunks

### DIFF
--- a/src/main/java/adubbz/nx/loader/SwitchLoader.java
+++ b/src/main/java/adubbz/nx/loader/SwitchLoader.java
@@ -131,8 +131,8 @@ public class SwitchLoader extends BinaryLoader
 
     @Override
     protected void loadProgramInto(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
-            MessageLog messageLog, Program program, TaskMonitor monitor) 
-                    throws IOException
+            MessageLog messageLog, Program program, TaskMonitor monitor)
+                    throws IOException, CancelledException
     {
         var space = program.getAddressFactory().getDefaultAddressSpace();
         


### PR DESCRIPTION
This PR hopefully closes #19 by disassembling the entire `.plt` section and creating thunked functions for every `PltEntry`.

I used ghidra's [ElfProgramBuilder](https://github.com/NationalSecurityAgency/ghidra/blob/de7c3eaee2a4bc993a402e371b039c2bb2d6c545/Ghidra/Features/Base/src/main/java/ghidra/app/util/opinion/ElfProgramBuilder.java) as a template and added the necessary steps from it.

That said, I don't know a lot about ELF or file formats in general, so I'm not sure if there are any missing cases or if this solution is incorrect.
I tested it with a few binaries myself and the results look right, but I lack the experience to actually judge that.