### PR TITLE
Fix relocations for imports by making elf symbol values relative to the image base

### DIFF
--- a/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java
+++ b/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java
@@ -430,7 +430,8 @@ public class NXProgramBuilder
                         Field elfSymbolValue = elfSymbol.getClass().getDeclaredField("st_value");
                         elfSymbolValue.setAccessible(true);
                         // Fix the value to be non-zero, instead pointing to our fake EXTERNAL block
-                        elfSymbolValue.set(elfSymbol, externalBlockAddrOffset);
+                        // make the symbol value relative to the image base, as that's how all other symbols are stored
+                        elfSymbolValue.set(elfSymbol, externalBlockAddrOffset - this.nxo.getBaseAddress());
                     } catch (NoSuchFieldException | IllegalAccessException e) {
                         Msg.error(this, "Couldn't find or set st_value field in ElfSymbol.", e);
                     }


### PR DESCRIPTION
Users of `ElfSymbol` assume that symbol values are relative to the image base, for example:

https://github.com/Adubbz/Ghidra-Switch-Loader/blob/1d54648abc017e18c93f8588fba821fc89935dab/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java#L340

`setupImports`, however sets it to an absolute address. This leads to issues with resolving GOT values and other imported addresses put into global memory, for example typeinfo: you get base address added twice and end up with pointers like `0xe20015b750` instead of `0x7100...`. This actually worked fine before ghidra 10.3 for some surprising reasons.

The underlying bug of using global address when setting the value but using it as relative offset was there from the start, but was masked because `ElfSymbol::setValue` function, which was used, did a cast to an int:

```java
	public void setValue(long value) {
		this.st_value = (int) value;
	}
```
[source](https://github.com/NationalSecurityAgency/ghidra/blob/79d8f164f8bb8b15cfb60c5d4faeb8e1c25d15ca/Ghidra/Features/Base/src/main/java/ghidra/app/util/bin/format/elf/ElfSymbol.java#L526-L528)

Because of this addresses like `0x710015b750` were truncated to `0x15b750`, which just happened to be a relative offset. The bug got resurfaced in https://github.com/Adubbz/Ghidra-Switch-Loader/pull/37, because the cast was now gone.