### PR TITLE
Increase import spacing so that large imported variables do not end up overlapping other imports

### DIFF
--- a/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java
+++ b/src/main/java/adubbz/nx/loader/common/NXProgramBuilder.java
@@ -410,7 +410,7 @@ public class NXProgramBuilder
                 lastAddrOff = block.getEnd().getOffset();
         }
         
-        int undefEntrySize = adapter.getOffsetSize(); // We create fake 1 byte functions for imports
+        int undefEntrySize = 0x1000; // We create fake 0x1000 regions for each import
         long externalBlockAddrOffset = ((lastAddrOff + 0xFFF) & ~0xFFF) + undefEntrySize; // plus 1 so we don't end up on the "end" symbol
         
         // Create the block where imports will be located


### PR DESCRIPTION
For some imports, 8/4 bytes currently allocated for each import are not enough. For example, when games are built with RTTI, they end up referencing `_ZTVN10__cxxabiv120__si_class_type_infoE+0x10`, which, with 8-byte imports, ends up putting XREFs on the wrong symbol:

![image](https://github.com/user-attachments/assets/c5ed649e-b13e-4a83-adf9-13b47875e294)

If the spacing is increased to, for example, `0x1000`, this becomes less of an issue (4K should be enough for every variable, right?):

![image](https://github.com/user-attachments/assets/a8a850b0-03f5-433f-94e6-7ced63269749)


This is how it works in [VitaLoaderRedux](https://github.com/CreepNT/VitaLoaderRedux) currently