### PR TITLE
bugfix & enhancement: IPC Emulator overhaul

### DIFF
--- a/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
+++ b/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
@@ -55,6 +55,8 @@ import org.python.google.common.collect.HashBiMap;
 import org.python.google.common.collect.Sets;
 
 import java.io.IOException;
+import java.io.File;
+import java.io.FileWriter;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -65,6 +67,11 @@ import static adubbz.nx.common.ElfCompatibilityProvider.R_FAKE_RELR;
 public class IPCAnalyzer extends AbstractAnalyzer 
 {
     private static final Pattern AARCH64_MEMORY_BASE_PATTERN = Pattern.compile("\\[\\s*([xw]\\d+|sp)\\b", Pattern.CASE_INSENSITIVE);
+    private static final String OPTION_EXPORT_IPC_JSON = "Export IPC metadata JSON";
+    private static final String OPTION_EXPORT_IPC_JSON_PATH = "IPC metadata JSON export path";
+
+    private boolean exportIpcJson = false;
+    private String exportIpcJsonPath = "";
 
     public IPCAnalyzer() 
     {
@@ -88,7 +95,17 @@ public class IPCAnalyzer extends AbstractAnalyzer
     @Override
     public void registerOptions(Options options, Program program) 
     {
-        // TODO: Symbol options
+        options.registerOption(OPTION_EXPORT_IPC_JSON, false, null,
+            "Export recovered IPC metadata to a JSON file after analysis.");
+        options.registerOption(OPTION_EXPORT_IPC_JSON_PATH, "", null,
+            "Path for exported IPC metadata JSON. If empty, exports beside the program executable.");
+    }
+
+    @Override
+    public void optionsChanged(Options options, Program program)
+    {
+        this.exportIpcJson = options.getBoolean(OPTION_EXPORT_IPC_JSON, false);
+        this.exportIpcJsonPath = options.getString(OPTION_EXPORT_IPC_JSON_PATH, "");
     }
 
     @Override
@@ -206,6 +223,7 @@ public class IPCAnalyzer extends AbstractAnalyzer
             }
 
             this.markupIpc(program, monitor, vtEntries, sTableProcessFuncMap, processFuncTraces, procFuncVtMap);
+            this.exportIpcJson(program, vtEntries, processFuncTraces, procFuncVtMap);
         }
         catch (Exception e)
         {
@@ -1145,6 +1163,180 @@ public class IPCAnalyzer extends AbstractAnalyzer
             trace.inInterfaces, trace.outInterfaces, trace.inHandles, trace.outHandles));
 
         return comment.toString();
+    }
+
+    private void exportIpcJson(Program program, List<IPCVTableEntry> vtEntries,
+                               Multimap<Address, IPCTrace> processFuncTraces,
+                               HashBiMap<Address, IPCVTableEntry> procFuncVtMap)
+    {
+        if (!this.exportIpcJson)
+            return;
+
+        File exportFile = this.getIpcJsonExportFile(program);
+
+        if (exportFile == null)
+            return;
+
+        try
+        {
+            File parent = exportFile.getParentFile();
+
+            if (parent != null && !parent.exists() && !parent.mkdirs())
+            {
+                Msg.warn(this, String.format("Failed to create IPC JSON export directory: %s", parent));
+                return;
+            }
+
+            try (FileWriter writer = new FileWriter(exportFile))
+            {
+                writer.write(this.formatIpcJson(program, vtEntries, processFuncTraces, procFuncVtMap));
+            }
+
+            Msg.info(this, String.format("Exported IPC metadata JSON to %s", exportFile.getAbsolutePath()));
+        }
+        catch (IOException | MemoryAccessException e)
+        {
+            Msg.warn(this, String.format("Failed to export IPC metadata JSON to %s: %s",
+                exportFile.getAbsolutePath(), e.getMessage()));
+        }
+    }
+
+    private File getIpcJsonExportFile(Program program)
+    {
+        if (this.exportIpcJsonPath != null && !this.exportIpcJsonPath.isBlank())
+            return new File(this.exportIpcJsonPath);
+
+        String executablePath = program.getExecutablePath();
+
+        if (executablePath == null || executablePath.isBlank())
+        {
+            Msg.warn(this, "IPC metadata JSON export requested, but no export path or executable path is available.");
+            return null;
+        }
+
+        return new File(executablePath + ".ipc.json");
+    }
+
+    private String formatIpcJson(Program program, List<IPCVTableEntry> vtEntries,
+                                 Multimap<Address, IPCTrace> processFuncTraces,
+                                 HashBiMap<Address, IPCVTableEntry> procFuncVtMap) throws MemoryAccessException
+    {
+        StringBuilder out = new StringBuilder();
+        AddressSpace aSpace = program.getAddressFactory().getDefaultAddressSpace();
+        boolean wroteInterface = false;
+
+        out.append("{\n");
+
+        for (IPCVTableEntry entry : vtEntries)
+        {
+            Address processFuncAddr = procFuncVtMap.inverse().get(entry);
+
+            if (processFuncAddr == null || !processFuncTraces.containsKey(processFuncAddr))
+                continue;
+
+            List<IPCTrace> traces = Lists.newArrayList(processFuncTraces.get(processFuncAddr).iterator());
+            traces = traces.stream()
+                .filter(trace -> trace.vtOffset != -1 && trace.hasDescription())
+                .sorted(Comparator.comparingLong(trace -> trace.cmdId))
+                .collect(Collectors.toList());
+
+            if (traces.isEmpty())
+                continue;
+
+            if (wroteInterface)
+                out.append(",\n");
+
+            String interfaceName = entry.abvName.replace("::vtable", "");
+            out.append("  \"").append(this.escapeJson(interfaceName)).append("\": {\n");
+
+            boolean wroteCommand = false;
+
+            for (IPCTrace trace : traces)
+            {
+                Address vtOffsetAddr = entry.addr.add(0x10 + trace.vtOffset);
+                Address ipcCmdImplAddr = aSpace.getAddress(program.getMemory().getLong(vtOffsetAddr));
+                Address ipcCmdTargetAddr = this.findDirectThunkTarget(program, ipcCmdImplAddr);
+                String commandName = IPCDatabase.getInstance().getCommandName(interfaceName, trace.cmdId);
+
+                if (wroteCommand)
+                    out.append(",\n");
+
+                out.append("    \"").append(trace.cmdId).append("\": {");
+                out.append("\"vt\": \"").append(this.formatHex(trace.vtOffset)).append("\"");
+                out.append(", \"func\": \"").append(this.formatHex(ipcCmdImplAddr.getOffset())).append("\"");
+                out.append(", \"lr\": \"").append(this.formatHex(trace.lr)).append("\"");
+                out.append(", \"inbytes\": ").append(trace.bytesIn);
+                out.append(", \"outbytes\": ").append(trace.bytesOut);
+
+                if (trace.hasBufferAttrs())
+                    out.append(", \"buffers\": ").append(trace.formatBufferAttrs());
+                else if (trace.bufferCount > 0)
+                    out.append(", \"buffer_count\": ").append(trace.bufferCount);
+
+                if (commandName != null)
+                    out.append(", \"name\": \"").append(this.escapeJson(commandName)).append("\"");
+
+                if (ipcCmdTargetAddr != null)
+                {
+                    Function targetFunction = program.getFunctionManager().getFunctionAt(ipcCmdTargetAddr);
+
+                    if (targetFunction != null)
+                    {
+                        out.append(", \"target\": \"").append(this.formatHex(ipcCmdTargetAddr.getOffset())).append("\"");
+                        out.append(", \"prototype\": \"")
+                            .append(this.escapeJson(targetFunction.getPrototypeString(false, false)))
+                            .append("\"");
+                    }
+                }
+
+                out.append("}");
+                wroteCommand = true;
+            }
+
+            out.append("\n  }");
+            wroteInterface = true;
+        }
+
+        out.append("\n}\n");
+        return out.toString();
+    }
+
+    private String formatHex(long value)
+    {
+        return String.format("0x%X", value);
+    }
+
+    private String escapeJson(String value)
+    {
+        if (value == null)
+            return "";
+
+        StringBuilder out = new StringBuilder();
+
+        for (int i = 0; i < value.length(); i++)
+        {
+            char c = value.charAt(i);
+
+            switch (c)
+            {
+                case '\\' -> out.append("\\\\");
+                case '"' -> out.append("\\\"");
+                case '\b' -> out.append("\\b");
+                case '\f' -> out.append("\\f");
+                case '\n' -> out.append("\\n");
+                case '\r' -> out.append("\\r");
+                case '\t' -> out.append("\\t");
+                default ->
+                {
+                    if (c < 0x20)
+                        out.append(String.format("\\u%04X", (int)c));
+                    else
+                        out.append(c);
+                }
+            }
+        }
+
+        return out.toString();
     }
 
     private void renameBranchTargetBufferParams(Program program, IPCTrace trace, Address ipcCmdTargetAddr)

--- a/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
+++ b/src/main/java/adubbz/nx/analyzer/IPCAnalyzer.java
@@ -28,10 +28,16 @@ import ghidra.program.model.address.AddressOutOfBoundsException;
 import ghidra.program.model.address.AddressSetView;
 import ghidra.program.model.address.AddressSpace;
 import ghidra.program.model.data.PointerDataType;
+import ghidra.program.model.data.Undefined8DataType;
 import ghidra.program.model.listing.CommentType;
 import ghidra.program.model.listing.Data;
+import ghidra.program.model.listing.Function;
 import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.Parameter;
+import ghidra.program.model.listing.ParameterImpl;
 import ghidra.program.model.listing.Program;
+import ghidra.program.model.listing.Variable;
+import ghidra.program.model.lang.Register;
 import ghidra.program.model.mem.Memory;
 import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.program.model.mem.MemoryBlock;
@@ -41,6 +47,7 @@ import ghidra.program.model.symbol.SymbolTable;
 import ghidra.program.model.symbol.FlowType;
 import ghidra.program.model.util.CodeUnitInsertionException;
 import ghidra.util.Msg;
+import ghidra.util.exception.DuplicateNameException;
 import ghidra.util.exception.InvalidInputException;
 import ghidra.util.task.TaskMonitor;
 import org.apache.commons.compress.utils.Lists;
@@ -49,12 +56,16 @@ import org.python.google.common.collect.Sets;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static adubbz.nx.common.ElfCompatibilityProvider.R_FAKE_RELR;
 
 public class IPCAnalyzer extends AbstractAnalyzer 
 {
+    private static final Pattern AARCH64_MEMORY_BASE_PATTERN = Pattern.compile("\\[\\s*([xw]\\d+|sp)\\b", Pattern.CASE_INSENSITIVE);
+
     public IPCAnalyzer() 
     {
         super("(Switch) IPC Analyzer", "Locates and labels IPC vtables, s_Tables and implementation functions.", AnalyzerType.INSTRUCTION_ANALYZER);
@@ -1029,19 +1040,15 @@ public class IPCAnalyzer extends AbstractAnalyzer
                         }
                     }
                     
-                    String implComment = """
-                            IPC INFORMATION
-                            Bytes In:       0x%X
-                            Bytes Out:      0x%X
-                            Buffer Count:   0x%X
-                            In Interfaces:  0x%X
-                            Out Interfaces: 0x%X
-                            In Handles:     0x%X
-                            Out Handles:    0x%X
-                            """;
-                    
-                    implComment = String.format(implComment, trace.bytesIn, trace.bytesOut, trace.bufferCount, trace.inInterfaces, trace.outInterfaces, trace.inHandles, trace.outHandles);
-                    program.getListing().setComment(ipcCmdImplAddr, CommentType.PLATE, implComment);
+                    program.getListing().setComment(ipcCmdImplAddr, CommentType.PLATE,
+                        this.formatIpcComment(trace, cmdName, ipcCmdImplAddr));
+
+                    if (ipcCmdTargetAddr != null)
+                    {
+                        program.getListing().setComment(ipcCmdTargetAddr, CommentType.PLATE,
+                            this.formatIpcComment(trace, cmdName, ipcCmdImplAddr));
+                        this.renameBranchTargetBufferParams(program, trace, ipcCmdTargetAddr);
+                    }
                 }
             }
             
@@ -1076,6 +1083,366 @@ public class IPCAnalyzer extends AbstractAnalyzer
         }
     }
 
+    private String formatIpcComment(IPCTrace trace, String cmdName, Address dispatchFuncAddr)
+    {
+        StringBuilder comment = new StringBuilder();
+
+        comment.append(String.format("""
+            IPC INFORMATION
+            Dispatch Func:     0x%X
+            Command:           0x%X
+            Command Dec:       %d
+            Command Name:      %s
+            LR:                0x%X
+            VT Offset:         0x%X
+            Bytes In:          0x%X
+            Bytes Out:         0x%X
+            Buffer Count:      0x%X
+            """,
+            dispatchFuncAddr.getOffset(), trace.cmdId, trace.cmdId,
+            cmdName != null ? cmdName : "<unknown>",
+            trace.lr, trace.vtOffset,
+            trace.bytesIn, trace.bytesOut, trace.bufferCount));
+
+        if (trace.hasBufferAttrs())
+        {
+            comment.append(String.format("""
+                Buffer Attrs:      %s
+                Buffer Directions: %s
+                Buffer Source:     %s
+                In Buffers:        0x%X
+                Out Buffers:       0x%X
+                """,
+                trace.formatBufferAttrs(), trace.formatBufferDirections(), trace.bufferAttrsSource,
+                trace.getInBufferCount(), trace.getOutBufferCount()));
+        }
+        else if (trace.bufferCount == 0)
+        {
+            comment.append("""
+                Buffer Attrs:      N/A
+                Buffer Directions: N/A
+                Buffer Source:     N/A
+                """);
+        }
+        else
+        {
+            // Probe output is only here to help debug unknown buffer-attribute layouts.
+            comment.append(String.format("""
+                Buffer Attrs:      <unknown>
+                Buffer Directions: <unknown>
+                Buffer Source:     <unknown>
+                Buffer Probe:      %s
+                """,
+                trace.bufferAttrsProbe != null ? trace.bufferAttrsProbe : "<none>"));
+        }
+
+        comment.append(String.format("""
+            In Interfaces:     0x%X
+            Out Interfaces:    0x%X
+            In Handles:        0x%X
+            Out Handles:       0x%X
+            """,
+            trace.inInterfaces, trace.outInterfaces, trace.inHandles, trace.outHandles));
+
+        return comment.toString();
+    }
+
+    private void renameBranchTargetBufferParams(Program program, IPCTrace trace, Address ipcCmdTargetAddr)
+    {
+        if (!trace.hasBufferAttrs())
+            return;
+
+        Function function = program.getFunctionManager().getFunctionAt(ipcCmdTargetAddr);
+
+        if (function == null)
+            return;
+
+        List<Integer> bufferParamOrdinals = this.findBranchTargetBufferParamOrdinals(program, ipcCmdTargetAddr,
+            trace.bufferAttrs.length);
+
+        if (bufferParamOrdinals.size() != trace.bufferAttrs.length)
+        {
+            Msg.debug(this, String.format(
+                "Skipping IPC buffer parameter rename at 0x%X: expected %d buffer params, found %d",
+                ipcCmdTargetAddr.getOffset(), trace.bufferAttrs.length, bufferParamOrdinals.size()));
+            return;
+        }
+
+        int maxOrdinal = bufferParamOrdinals.stream().mapToInt(Integer::intValue).max().orElse(-1);
+
+        if (function.getParameterCount() <= maxOrdinal)
+        {
+            if (!this.commitBranchTargetRegisterParams(program, function, bufferParamOrdinals, trace.bufferAttrs))
+            {
+                Msg.debug(this, String.format(
+                    "Skipping IPC buffer parameter rename at 0x%X: function has %d params, needs ordinal %d",
+                    ipcCmdTargetAddr.getOffset(), function.getParameterCount(), maxOrdinal));
+                return;
+            }
+        }
+
+        int inIndex = 0;
+        int outIndex = 0;
+        int inOutIndex = 0;
+
+        for (int i = 0; i < trace.bufferAttrs.length; i++)
+        {
+            int attr = trace.bufferAttrs[i];
+            String name;
+
+            boolean isIn = (attr & IPCTrace.BUFFER_ATTR_IN) != 0;
+            boolean isOut = (attr & IPCTrace.BUFFER_ATTR_OUT) != 0;
+
+            if (isIn && isOut)
+                name = "inout_buf" + inOutIndex++;
+            else if (isOut)
+                name = "out_buf" + outIndex++;
+            else if (isIn)
+                name = "in_buf" + inIndex++;
+            else
+                continue;
+
+            Parameter parameter = function.getParameter(bufferParamOrdinals.get(i));
+
+            if (parameter == null || parameter.getName().equals(name))
+                continue;
+
+            try
+            {
+                parameter.setName(name, SourceType.ANALYSIS);
+            }
+            catch (DuplicateNameException | InvalidInputException e)
+            {
+                Msg.warn(this, String.format("Failed to rename IPC buffer parameter '%s' at 0x%X: %s",
+                    name, ipcCmdTargetAddr.getOffset(), e.getMessage()));
+            }
+        }
+    }
+
+    private boolean commitBranchTargetRegisterParams(Program program, Function function,
+                                                     List<Integer> bufferParamOrdinals, int[] bufferAttrs)
+    {
+        int maxOrdinal = Math.max(
+            bufferParamOrdinals.stream().mapToInt(Integer::intValue).max().orElse(-1),
+            this.findMaxReferencedParamOrdinal(program, function.getEntryPoint()));
+
+        if (maxOrdinal < 0)
+            return false;
+
+        Map<Integer, String> bufferParamNames = new HashMap<>();
+        int inIndex = 0;
+        int outIndex = 0;
+        int inOutIndex = 0;
+
+        for (int i = 0; i < bufferAttrs.length; i++)
+        {
+            int attr = bufferAttrs[i];
+            boolean isIn = (attr & IPCTrace.BUFFER_ATTR_IN) != 0;
+            boolean isOut = (attr & IPCTrace.BUFFER_ATTR_OUT) != 0;
+            String name;
+
+            if (isIn && isOut)
+                name = "inout_buf" + inOutIndex++;
+            else if (isOut)
+                name = "out_buf" + outIndex++;
+            else if (isIn)
+                name = "in_buf" + inIndex++;
+            else
+                continue;
+
+            bufferParamNames.put(bufferParamOrdinals.get(i), name);
+        }
+
+        List<Variable> parameters = new ArrayList<>();
+
+        try
+        {
+            for (int ordinal = 0; ordinal <= maxOrdinal; ordinal++)
+            {
+                Parameter existing = ordinal < function.getParameterCount() ? function.getParameter(ordinal) : null;
+                String name = bufferParamNames.get(ordinal);
+
+                if (name == null)
+                    name = existing != null && !existing.getName().isBlank() ? existing.getName() : "param_" + (ordinal + 1);
+
+                Register register = program.getRegister("x" + ordinal);
+
+                if (register == null)
+                    return false;
+
+                parameters.add(new ParameterImpl(name, Undefined8DataType.dataType, register, program,
+                    SourceType.ANALYSIS));
+            }
+
+            function.replaceParameters(parameters, Function.FunctionUpdateType.CUSTOM_STORAGE, true,
+                SourceType.ANALYSIS);
+            return true;
+        }
+        catch (DuplicateNameException | InvalidInputException e)
+        {
+            Msg.warn(this, String.format("Failed to commit IPC branch target parameters at 0x%X: %s",
+                function.getEntryPoint().getOffset(), e.getMessage()));
+            return false;
+        }
+    }
+
+    private List<Integer> findBranchTargetBufferParamOrdinals(Program program, Address ipcCmdTargetAddr,
+                                                               int expectedBufferCount)
+    {
+        LinkedHashSet<Integer> bufferParamOrdinals = new LinkedHashSet<>();
+        Map<String, Integer> registerParamOrdinals = new HashMap<>();
+
+        for (int i = 0; i < 8; i++)
+            registerParamOrdinals.put("x" + i, i);
+
+        Instruction instruction = program.getListing().getInstructionAt(ipcCmdTargetAddr);
+
+        for (int i = 0; instruction != null && i < 120 && bufferParamOrdinals.size() < expectedBufferCount; i++)
+        {
+            this.trackRegisterAlias(instruction, registerParamOrdinals);
+
+            String baseRegister = this.getMemoryBaseRegister(instruction);
+
+            if (baseRegister != null)
+            {
+                Integer ordinal = registerParamOrdinals.get(baseRegister);
+
+                if (ordinal != null && ordinal > 0)
+                    bufferParamOrdinals.add(ordinal);
+            }
+
+            instruction = instruction.getNext();
+        }
+
+        return Lists.newArrayList(bufferParamOrdinals.iterator());
+    }
+
+    private int findMaxReferencedParamOrdinal(Program program, Address functionAddr)
+    {
+        int maxOrdinal = -1;
+        Instruction instruction = program.getListing().getInstructionAt(functionAddr);
+
+        for (int i = 0; instruction != null && i < 120; i++)
+        {
+            for (int operandIndex = 0; operandIndex < instruction.getNumOperands(); operandIndex++)
+            {
+                for (Object object : instruction.getOpObjects(operandIndex))
+                {
+                    if (object instanceof Register register)
+                    {
+                        String normalizedName = this.normalizeRegisterName(register.getName());
+                        int ordinal = this.getParamRegisterOrdinal(normalizedName);
+
+                        if (ordinal >= 0)
+                            maxOrdinal = Math.max(maxOrdinal, ordinal);
+                    }
+                }
+            }
+
+            instruction = instruction.getNext();
+        }
+
+        return maxOrdinal;
+    }
+
+    private int getParamRegisterOrdinal(String normalizedName)
+    {
+        if (normalizedName == null || !normalizedName.startsWith("x"))
+            return -1;
+
+        try
+        {
+            int ordinal = Integer.parseInt(normalizedName.substring(1));
+            return ordinal >= 0 && ordinal <= 7 ? ordinal : -1;
+        }
+        catch (NumberFormatException e)
+        {
+            return -1;
+        }
+    }
+
+    private void trackRegisterAlias(Instruction instruction, Map<String, Integer> registerParamOrdinals)
+    {
+        String mnemonic = instruction.getMnemonicString();
+
+        if (!"mov".equals(mnemonic))
+            return;
+
+        Register destRegister = this.getOperandRegister(instruction, 0);
+
+        if (destRegister == null)
+            return;
+
+        String destName = this.normalizeRegisterName(destRegister.getName());
+
+        if (destName == null)
+            return;
+
+        Register sourceRegister = this.getOperandRegister(instruction, 1);
+
+        if (sourceRegister == null)
+        {
+            registerParamOrdinals.remove(destName);
+            return;
+        }
+
+        String sourceName = this.normalizeRegisterName(sourceRegister.getName());
+        Integer sourceOrdinal = sourceName != null ? registerParamOrdinals.get(sourceName) : null;
+
+        if (sourceOrdinal != null)
+            registerParamOrdinals.put(destName, sourceOrdinal);
+        else
+            registerParamOrdinals.remove(destName);
+    }
+
+    private Register getOperandRegister(Instruction instruction, int operandIndex)
+    {
+        if (operandIndex >= instruction.getNumOperands())
+            return null;
+
+        for (Object object : instruction.getOpObjects(operandIndex))
+        {
+            if (object instanceof Register register)
+                return register;
+        }
+
+        return null;
+    }
+
+    private String getMemoryBaseRegister(Instruction instruction)
+    {
+        for (int i = 0; i < instruction.getNumOperands(); i++)
+        {
+            String operand = instruction.getDefaultOperandRepresentation(i);
+
+            if (operand == null || operand.indexOf('[') == -1)
+                continue;
+
+            Matcher matcher = AARCH64_MEMORY_BASE_PATTERN.matcher(operand);
+
+            if (matcher.find())
+                return this.normalizeRegisterName(matcher.group(1));
+        }
+
+        return null;
+    }
+
+    private String normalizeRegisterName(String registerName)
+    {
+        if (registerName == null)
+            return null;
+
+        registerName = registerName.toLowerCase(Locale.ROOT);
+
+        if (registerName.startsWith("w"))
+            return "x" + registerName.substring(1);
+
+        if (registerName.startsWith("x"))
+            return registerName;
+
+        return null;
+    }
+
     private Address findDirectThunkTarget(Program program, Address thunkAddr)
     {
         Instruction instruction = program.getListing().getInstructionAt(thunkAddr);
@@ -1106,7 +1473,7 @@ public class IPCAnalyzer extends AbstractAnalyzer
 
         return null;
     }
-    
+
     protected int getProcFuncVTableSize(Multimap<Address, IPCTrace> processFuncTraces, Address procFuncAddr)
     {
         if (!processFuncTraces.containsKey(procFuncAddr) || processFuncTraces.get(procFuncAddr).isEmpty())

--- a/src/main/java/adubbz/nx/analyzer/ipc/IPCEmulator.java
+++ b/src/main/java/adubbz/nx/analyzer/ipc/IPCEmulator.java
@@ -35,12 +35,32 @@ import ghidra.util.task.TaskMonitorAdapter;
 import org.apache.commons.compress.utils.Lists;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class IPCEmulator 
 {
+    private static final int MAX_BUFFER_ATTRS = 8;
+    private static final int BUFFER_ATTR_IN = IPCTrace.BUFFER_ATTR_IN;
+    private static final int BUFFER_ATTR_OUT = IPCTrace.BUFFER_ATTR_OUT;
+    private static final int BUFFER_ATTR_HIPC_MAP_ALIAS = 4;
+    private static final int BUFFER_ATTR_HIPC_POINTER = 8;
+    private static final int BUFFER_ATTR_HIPC_AUTO_SELECT = 32;
+    private static final int BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_SECURE = 64;
+    private static final int BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_DEVICE = 128;
+    private static final int BUFFER_ATTR_VALID_MASK =
+        BUFFER_ATTR_IN |
+        BUFFER_ATTR_OUT |
+        BUFFER_ATTR_HIPC_MAP_ALIAS |
+        BUFFER_ATTR_HIPC_POINTER |
+        16 |
+        BUFFER_ATTR_HIPC_AUTO_SELECT |
+        BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_SECURE |
+        BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_DEVICE;
+
     private Program program;
     public boolean hasSetup;
     
@@ -302,8 +322,10 @@ public class IPCEmulator
         disassembler.disassemble(procFuncAddr, null);
 
         final int MAX_INSTRUCTIONS_WITH_META = 100_000;
-        final int MAX_INSTRUCTIONS_NO_META   = 500;
+        final int MAX_INSTRUCTIONS_NO_META   = 5_000;
+        final int MAX_NO_META_PC_HITS        = 256;
         int instructionCount = 0;
+        Map<Long, Integer> noMetaPcHits = new HashMap<>();
 
         while (true)
         {
@@ -317,8 +339,22 @@ public class IPCEmulator
             if (emu.getExecuteAddress().getOffset() == 0)
                 break;
 
+            if (!hasMeta)
+            {
+                int pcHits = noMetaPcHits.getOrDefault(pc, 0) + 1;
+                noMetaPcHits.put(pc, pcHits);
+
+                if (pcHits > MAX_NO_META_PC_HITS)
+                {
+                    this.currentTrace.timedOut = true;
+                    break;
+                }
+            }
+
             if (++instructionCount > limit)
             {
+                this.currentTrace.timedOut = true;
+
                 if (!hasMeta)
                 {
                     // Silent — this is just a command that doesn't exist in this interface
@@ -461,76 +497,22 @@ public class IPCEmulator
         if (metaInfoSize != this.state.getChunk(metaInfo, this.sLang.getDefaultSpace(), metaInfoPtr, metaInfo.length, true))
             throw new RuntimeException("Failed to read meta info");
 
-        // Read a little-endian uint16 from a byte array
-        // Layouts: { baseOffset, useUint16 }
-        // [0] = base offset, [1] = 1 for uint16 fields, 0 for uint32 fields
-        // Added more offsets for compatibility with different SDK versions (especially 9.0.0)
-        int[][] layouts = new int[][] {
-            { 0x00, 1 },   // modern SDK: uint16 fields at 0x0
-            { 0x08, 0 },   // legacy SDK: uint32 fields at 0x8
-            { 0x10, 0 },   // legacy SDK: uint32 fields at 0x10
-            { 0x18, 0 },   // additional legacy SDK variant: uint32 fields at 0x18
-            { 0x20, 0 },   // additional legacy SDK variant: uint32 fields at 0x20
-        };
-
         try
         {
-            for (int[] layout : layouts)
+            Metadata metadata = decodeMetadata(metaInfo);
+
+            if (metadata != null)
             {
-                int base = layout[0];
-                boolean wide = layout[1] == 0;
-
-                long rawBytesIn, rawBytesOut, bufferCount, inInterfaces, outInterfaces, inHandles, outHandles;
-
-                if (!wide)
-                {
-                    // Modern SDK layout:
-                    // [0x00] uint16 rawBytesIn
-                    // [0x02] uint16 rawBytesOut
-                    // [0x04] uint8  bufferCount
-                    // [0x05] uint8  inInterfaces
-                    // [0x06] uint8  outInterfaces
-                    // [0x07] uint8  inHandles
-                    // [0x08] uint8  outHandles
-                    rawBytesIn    = readU16LE(metaInfo, base + 0x00);
-                    rawBytesOut   = readU16LE(metaInfo, base + 0x02);
-                    bufferCount   = metaInfo[base + 0x04] & 0xFFL;
-                    inInterfaces  = metaInfo[base + 0x05] & 0xFFL;
-                    outInterfaces = metaInfo[base + 0x06] & 0xFFL;
-                    inHandles     = metaInfo[base + 0x07] & 0xFFL;
-                    outHandles    = metaInfo[base + 0x08] & 0xFFL;
-                }
-                else
-                {
-                    // uint32 little-endian reads (legacy SDK variants)
-                    rawBytesIn    = readU32LE(metaInfo, base + 0x00);
-                    rawBytesOut   = readU32LE(metaInfo, base + 0x08);
-                    bufferCount   = readU32LE(metaInfo, base + 0x10);
-                    inInterfaces  = readU32LE(metaInfo, base + 0x14);
-                    outInterfaces = readU32LE(metaInfo, base + 0x18);
-                    inHandles     = readU32LE(metaInfo, base + 0x1C);
-                    outHandles    = readU32LE(metaInfo, base + 0x20);
-                }
-
-                long bytesIn  = rawBytesIn  - 0x10;
-                long bytesOut = rawBytesOut - 0x10;
-
-                // Relaxed validation: allow slightly larger buffers for legacy SDKs
-                if (rawBytesIn  < 0x10 || rawBytesIn  > 0x4010L) continue;
-                if (rawBytesOut < 0x10 || rawBytesOut > 0x4010L) continue;
-                if (bufferCount  > 20) continue;
-                if (inInterfaces > 20) continue;
-                if (outInterfaces> 20) continue;
-                if (inHandles    > 20) continue;
-                if (outHandles   > 20) continue;
-
-                this.currentTrace.bytesIn       = bytesIn;
-                this.currentTrace.bytesOut      = bytesOut;
-                this.currentTrace.bufferCount   = bufferCount;
-                this.currentTrace.inInterfaces  = inInterfaces;
-                this.currentTrace.outInterfaces = outInterfaces;
-                this.currentTrace.inHandles     = inHandles;
-                this.currentTrace.outHandles    = outHandles;
+                this.currentTrace.bytesIn       = metadata.bytesIn;
+                this.currentTrace.bytesOut      = metadata.bytesOut;
+                this.currentTrace.bufferCount   = metadata.bufferCount;
+                this.currentTrace.bufferAttrs   = metadata.bufferAttrs;
+                this.currentTrace.bufferAttrsSource = metadata.bufferAttrsSource;
+                this.currentTrace.bufferAttrsProbe = metadata.bufferAttrsProbe;
+                this.currentTrace.inInterfaces  = metadata.inInterfaces;
+                this.currentTrace.outInterfaces = metadata.outInterfaces;
+                this.currentTrace.inHandles     = metadata.inHandles;
+                this.currentTrace.outHandles    = metadata.outHandles;
                 this.currentTrace.lr            = this.state.getValue("x30");
 
                 if (this.currentTrace.inInterfaces > 0)
@@ -586,6 +568,332 @@ public class IPCEmulator
         }
     }
 
+    private static Metadata decodeMetadata(byte[] metaInfo)
+    {
+        Metadata metadata = decodeRuntimeMetadata(metaInfo);
+        if (metadata != null && looksLikeRuntimeMetadata(metaInfo))
+            return metadata;
+
+        metadata = decodeLegacyCompactMetadata(metaInfo, 0x00);
+        if (metadata != null)
+            return metadata;
+
+        int[] wideBases = new int[] { 0x08, 0x10, 0x18, 0x20 };
+        for (int base : wideBases)
+        {
+            metadata = decodeLegacyWideMetadata(metaInfo, base);
+            if (metadata != null)
+                return metadata;
+        }
+
+        return null;
+    }
+
+    private static Metadata decodeLegacyCompactMetadata(byte[] metaInfo, int base)
+    {
+        // Legacy Nintendo SDK-style metadata stores CMIF header-inclusive raw
+        // sizes followed by object/buffer/handle counts.
+        long rawBytesIn    = readU16LE(metaInfo, base + 0x00);
+        long rawBytesOut   = readU16LE(metaInfo, base + 0x02);
+        long inInterfaces  = metaInfo[base + 0x04] & 0xFFL;
+        long bufferCount   = metaInfo[base + 0x05] & 0xFFL;
+        long outInterfaces = metaInfo[base + 0x06] & 0xFFL;
+        long inHandles     = metaInfo[base + 0x07] & 0xFFL;
+        long outHandles    = metaInfo[base + 0x08] & 0xFFL;
+
+        if (!isValidLegacyMetadata(rawBytesIn, rawBytesOut, bufferCount, inInterfaces, outInterfaces, inHandles, outHandles))
+            return null;
+
+        BufferAttrsResult bufferAttrs = decodeCompactBufferAttrs(metaInfo, base, bufferCount);
+        String bufferAttrsProbe = bufferAttrs == null ? describeCompactBufferAttrProbes(metaInfo, base, bufferCount) : null;
+
+        return new Metadata(rawBytesIn - 0x10, rawBytesOut - 0x10, bufferCount, inInterfaces,
+            outInterfaces, inHandles, outHandles, bufferAttrs, bufferAttrsProbe);
+    }
+
+    private static Metadata decodeLegacyWideMetadata(byte[] metaInfo, int base)
+    {
+        long rawBytesIn    = readU32LE(metaInfo, base + 0x00);
+        long rawBytesOut   = readU32LE(metaInfo, base + 0x08);
+        long inInterfaces  = readU32LE(metaInfo, base + 0x10);
+        long bufferCount   = readU32LE(metaInfo, base + 0x14);
+        long outInterfaces = readU32LE(metaInfo, base + 0x18);
+        long inHandles     = readU32LE(metaInfo, base + 0x1C);
+        long outHandles    = readU32LE(metaInfo, base + 0x20);
+
+        if (!isValidLegacyMetadata(rawBytesIn, rawBytesOut, bufferCount, inInterfaces, outInterfaces, inHandles, outHandles))
+            return null;
+
+        BufferAttrsResult bufferAttrs = decodeWideBufferAttrs(metaInfo, base, bufferCount);
+        String bufferAttrsProbe = bufferAttrs == null ? describeWideBufferAttrProbes(metaInfo, base, bufferCount) : null;
+
+        return new Metadata(rawBytesIn - 0x10, rawBytesOut - 0x10, bufferCount, inInterfaces,
+            outInterfaces, inHandles, outHandles, bufferAttrs, bufferAttrsProbe);
+    }
+
+    private static Metadata decodeRuntimeMetadata(byte[] metaInfo)
+    {
+        // Atmosphere's ServerMessageRuntimeMetadata is an eight-byte POD:
+        // in data size, unaligned out data size, in/out header sizes, in/out object counts.
+        long bytesIn       = readU16LE(metaInfo, 0x00);
+        long bytesOut      = readU16LE(metaInfo, 0x02);
+        long inHeadersSize = metaInfo[0x04] & 0xFFL;
+        long outHeadersSize= metaInfo[0x05] & 0xFFL;
+        long inInterfaces  = metaInfo[0x06] & 0xFFL;
+        long outInterfaces = metaInfo[0x07] & 0xFFL;
+
+        if (bytesIn > 0x4000L || bytesOut > 0x4000L)
+            return null;
+        if (!isValidHeaderSize(inHeadersSize) || !isValidHeaderSize(outHeadersSize))
+            return null;
+        if (inInterfaces > 20 || outInterfaces > 20)
+            return null;
+
+        return new Metadata(bytesIn, bytesOut, 0, inInterfaces, outInterfaces, 0, 0, null, null);
+    }
+
+    private static BufferAttrsResult decodeCompactBufferAttrs(byte[] metaInfo, int base, long bufferCount)
+    {
+        int[] offsets = new int[] { base + 0x0A, base + 0x09, alignUp(base + 0x09, 4), base + 0x10 };
+
+        for (int offset : offsets)
+        {
+            int[] attrs = readByteBufferAttrs(metaInfo, offset, bufferCount);
+            if (attrs != null)
+                return new BufferAttrsResult(attrs, String.format("legacy-compact/u8+0x%X", offset - base));
+        }
+
+        return null;
+    }
+
+    private static String describeCompactBufferAttrProbes(byte[] metaInfo, int base, long bufferCount)
+    {
+        int[] offsets = new int[] { base + 0x0A, base + 0x09, alignUp(base + 0x09, 4), base + 0x10 };
+        StringBuilder out = new StringBuilder();
+
+        for (int offset : offsets)
+            appendProbe(out, String.format("u8+0x%X", offset - base), readRawByteAttrs(metaInfo, offset, bufferCount));
+
+        return out.toString();
+    }
+
+    private static BufferAttrsResult decodeWideBufferAttrs(byte[] metaInfo, int base, long bufferCount)
+    {
+        int[] offsets = new int[] { base + 0x24, alignUp(base + 0x24, 8), base + 0x30 };
+
+        for (int offset : offsets)
+        {
+            int[] attrs = readU32BufferAttrs(metaInfo, offset, bufferCount);
+            if (attrs != null)
+                return new BufferAttrsResult(attrs, String.format("legacy-wide/u32+0x%X", offset - base));
+        }
+
+        for (int offset : offsets)
+        {
+            int[] attrs = readByteBufferAttrs(metaInfo, offset, bufferCount);
+            if (attrs != null)
+                return new BufferAttrsResult(attrs, String.format("legacy-wide/u8+0x%X", offset - base));
+        }
+
+        return null;
+    }
+
+    private static String describeWideBufferAttrProbes(byte[] metaInfo, int base, long bufferCount)
+    {
+        int[] offsets = new int[] { base + 0x24, alignUp(base + 0x24, 8), base + 0x30 };
+        StringBuilder out = new StringBuilder();
+
+        for (int offset : offsets)
+            appendProbe(out, String.format("u32+0x%X", offset - base), readRawU32Attrs(metaInfo, offset, bufferCount));
+
+        for (int offset : offsets)
+            appendProbe(out, String.format("u8+0x%X", offset - base), readRawByteAttrs(metaInfo, offset, bufferCount));
+
+        return out.toString();
+    }
+
+    private static void appendProbe(StringBuilder out, String name, String value)
+    {
+        if (out.length() > 0)
+            out.append("; ");
+
+        out.append(name).append("=").append(value);
+    }
+
+    private static int[] readByteBufferAttrs(byte[] metaInfo, int offset, long bufferCount)
+    {
+        if (!isValidBufferAttrCount(bufferCount) || offset < 0 || offset + bufferCount > metaInfo.length)
+            return null;
+
+        int[] attrs = new int[(int)bufferCount];
+
+        for (int i = 0; i < attrs.length; i++)
+        {
+            attrs[i] = metaInfo[offset + i] & 0xFF;
+
+            if (!isValidBufferAttr(attrs[i]))
+                return null;
+        }
+
+        return attrs;
+    }
+
+    private static String readRawByteAttrs(byte[] metaInfo, int offset, long bufferCount)
+    {
+        if (!isValidBufferAttrCount(bufferCount) || offset < 0 || offset + bufferCount > metaInfo.length)
+            return "<range>";
+
+        StringBuilder out = new StringBuilder("[");
+
+        for (int i = 0; i < bufferCount; i++)
+        {
+            if (i > 0)
+                out.append(",");
+
+            out.append(metaInfo[offset + i] & 0xFF);
+        }
+
+        return out.append("]").toString();
+    }
+
+    private static int[] readU32BufferAttrs(byte[] metaInfo, int offset, long bufferCount)
+    {
+        if (!isValidBufferAttrCount(bufferCount) || offset < 0 || offset + bufferCount * 4 > metaInfo.length)
+            return null;
+
+        int[] attrs = new int[(int)bufferCount];
+
+        for (int i = 0; i < attrs.length; i++)
+        {
+            long attr = readU32LE(metaInfo, offset + i * 4);
+
+            if (!isValidBufferAttr(attr))
+                return null;
+
+            attrs[i] = (int)attr;
+        }
+
+        return attrs;
+    }
+
+    private static String readRawU32Attrs(byte[] metaInfo, int offset, long bufferCount)
+    {
+        if (!isValidBufferAttrCount(bufferCount) || offset < 0 || offset + bufferCount * 4 > metaInfo.length)
+            return "<range>";
+
+        StringBuilder out = new StringBuilder("[");
+
+        for (int i = 0; i < bufferCount; i++)
+        {
+            if (i > 0)
+                out.append(",");
+
+            out.append(readU32LE(metaInfo, offset + i * 4));
+        }
+
+        return out.append("]").toString();
+    }
+
+    private static boolean isValidBufferAttrCount(long bufferCount)
+    {
+        return bufferCount > 0 && bufferCount <= MAX_BUFFER_ATTRS;
+    }
+
+    private static boolean isValidBufferAttr(long attr)
+    {
+        if (attr <= 0 || (attr & ~BUFFER_ATTR_VALID_MASK) != 0)
+            return false;
+
+        if ((attr & (BUFFER_ATTR_IN | BUFFER_ATTR_OUT)) == 0)
+            return false;
+
+        int transferModes = 0;
+
+        if ((attr & BUFFER_ATTR_HIPC_MAP_ALIAS) != 0) transferModes++;
+        if ((attr & BUFFER_ATTR_HIPC_POINTER) != 0) transferModes++;
+        if ((attr & BUFFER_ATTR_HIPC_AUTO_SELECT) != 0) transferModes++;
+
+        if (transferModes != 1)
+            return false;
+
+        return (attr & (BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_SECURE |
+            BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_DEVICE)) !=
+            (BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_SECURE |
+                BUFFER_ATTR_HIPC_MAP_TRANSFER_ALLOWS_NON_DEVICE);
+    }
+
+    private static int alignUp(int value, int align)
+    {
+        return (value + align - 1) & -align;
+    }
+
+    private static class BufferAttrsResult
+    {
+        private final int[] attrs;
+        private final String source;
+
+        private BufferAttrsResult(int[] attrs, String source)
+        {
+            this.attrs = attrs;
+            this.source = source;
+        }
+    }
+
+    private static boolean isValidLegacyMetadata(long rawBytesIn, long rawBytesOut, long bufferCount,
+                                                 long inInterfaces, long outInterfaces,
+                                                 long inHandles, long outHandles)
+    {
+        if (rawBytesIn  < 0x10 || rawBytesIn  > 0x4010L) return false;
+        if (rawBytesOut < 0x10 || rawBytesOut > 0x4010L) return false;
+        if (bufferCount  > 20) return false;
+        if (inInterfaces > 20) return false;
+        if (outInterfaces> 20) return false;
+        if (inHandles    > 20) return false;
+        return outHandles <= 20;
+    }
+
+    private static boolean isValidHeaderSize(long size)
+    {
+        return size == 0 || size == 0x10 || size == 0x20 || size == 0x30;
+    }
+
+    private static boolean looksLikeRuntimeMetadata(byte[] metaInfo)
+    {
+        return isValidHeaderSize(metaInfo[0x04] & 0xFFL) &&
+            isValidHeaderSize(metaInfo[0x05] & 0xFFL) &&
+            ((metaInfo[0x04] & 0xFFL) >= 0x10 || (metaInfo[0x05] & 0xFFL) >= 0x10);
+    }
+
+    private static class Metadata
+    {
+        private final long bytesIn;
+        private final long bytesOut;
+        private final long bufferCount;
+        private final int[] bufferAttrs;
+        private final String bufferAttrsSource;
+        private final String bufferAttrsProbe;
+        private final long inInterfaces;
+        private final long outInterfaces;
+        private final long inHandles;
+        private final long outHandles;
+
+        private Metadata(long bytesIn, long bytesOut, long bufferCount, long inInterfaces,
+                         long outInterfaces, long inHandles, long outHandles,
+                         BufferAttrsResult bufferAttrs, String bufferAttrsProbe)
+        {
+            this.bytesIn = bytesIn;
+            this.bytesOut = bytesOut;
+            this.bufferCount = bufferCount;
+            this.bufferAttrs = bufferAttrs != null ? bufferAttrs.attrs : null;
+            this.bufferAttrsSource = bufferAttrs != null ? bufferAttrs.source : null;
+            this.bufferAttrsProbe = bufferAttrsProbe;
+            this.inInterfaces = inInterfaces;
+            this.outInterfaces = outInterfaces;
+            this.inHandles = inHandles;
+            this.outHandles = outHandles;
+        }
+    }
+
     private static long readU16LE(byte[] buf, int off)
     {
         return ((buf[off] & 0xFFL)) | ((buf[off + 1] & 0xFFL) << 8);
@@ -618,8 +926,9 @@ public class IPCEmulator
     private boolean GetBuffers()
     {
         long out = this.state.getValue("x1");
+        long bufferCount = Math.max(this.currentTrace.bufferCount, 0);
         
-        for (long i = out; i < out + this.currentTrace.bufferCount * 0x10; i += 0x10)
+        for (long i = out; i < out + bufferCount * 0x10; i += 0x10)
         {
             this.setLong(i, this.bufferMemory);
             this.setLong(i + 0x8, this.bufferSize);
@@ -631,6 +940,12 @@ public class IPCEmulator
     
     private boolean GetInNativeHandles()
     {
+        long out = this.state.getValue("x1");
+        long handleCount = Math.max(this.currentTrace.inHandles, 0);
+
+        for (long i = 0; i < handleCount; i++)
+            this.setInt(out + i * 0x4, 0xCAFE0000L + i);
+
         this.returnFromFunc(0);
         return true;
     }

--- a/src/main/java/adubbz/nx/analyzer/ipc/IPCTrace.java
+++ b/src/main/java/adubbz/nx/analyzer/ipc/IPCTrace.java
@@ -6,16 +6,22 @@
  */
 package adubbz.nx.analyzer.ipc;
 
-import ghidra.util.Msg;
+import java.util.StringJoiner;
 
 public class IPCTrace 
 {
+    public static final int BUFFER_ATTR_IN = 1;
+    public static final int BUFFER_ATTR_OUT = 2;
+
     public final long cmdId;
     public final long procFuncAddr;
     
     public long bytesIn = -1;
     public long bytesOut = -1;
     public long bufferCount = -1;
+    public int[] bufferAttrs = null;
+    public String bufferAttrsSource = null;
+    public String bufferAttrsProbe = null;
     public long inInterfaces = -1;
     public long outInterfaces = -1;
     public long inHandles = -1;
@@ -23,6 +29,7 @@ public class IPCTrace
     public long lr = -1;
     
     public long vtOffset = -1;
+    public boolean timedOut = false;
     
     public IPCTrace(int cmdId, long procFuncAddr)
     {
@@ -35,38 +42,86 @@ public class IPCTrace
         return bytesIn != -1 || bytesOut != -1 || bufferCount != -1 || inInterfaces != -1 ||
                 outInterfaces != -1 || inHandles != -1 || outHandles != -1 || lr != -1;
     }
+
+    public boolean hasBufferAttrs()
+    {
+        return this.bufferAttrs != null && this.bufferAttrs.length > 0;
+    }
+
+    public int getInBufferCount()
+    {
+        return this.getBufferCountByAttr(BUFFER_ATTR_IN);
+    }
+
+    public int getOutBufferCount()
+    {
+        return this.getBufferCountByAttr(BUFFER_ATTR_OUT);
+    }
+
+    public String formatBufferAttrs()
+    {
+        StringJoiner joiner = new StringJoiner(", ", "[", "]");
+
+        if (this.bufferAttrs != null)
+        {
+            for (int attr : this.bufferAttrs)
+                joiner.add(String.format("%d", attr));
+        }
+
+        return joiner.toString();
+    }
+
+    public String formatBufferDirections()
+    {
+        StringJoiner joiner = new StringJoiner(", ", "[", "]");
+
+        if (this.bufferAttrs != null)
+        {
+            for (int attr : this.bufferAttrs)
+                joiner.add(formatBufferDirection(attr));
+        }
+
+        return joiner.toString();
+    }
+
+    private int getBufferCountByAttr(int attrMask)
+    {
+        int count = 0;
+
+        if (this.bufferAttrs != null)
+        {
+            for (int attr : this.bufferAttrs)
+            {
+                if ((attr & attrMask) != 0)
+                    count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static String formatBufferDirection(int attr)
+    {
+        boolean isIn = (attr & BUFFER_ATTR_IN) != 0;
+        boolean isOut = (attr & BUFFER_ATTR_OUT) != 0;
+
+        if (isIn && isOut)
+            return "in/out";
+        if (isIn)
+            return "in";
+        if (isOut)
+            return "out";
+
+        return "unknown";
+    }
     
     public boolean isCorrect()
     {
         if (!this.hasDescription())
         {
-            return true;
+            return !this.timedOut;
         }
 
         return vtOffset != -1;
-    }
-    
-    public void printTrace()
-    {
-        String out = """
-
-                --------------------
-                0x%X, Cmd 0x%X     \s
-                --------------------
-                Lr:             0x%X
-                Vt:             0x%X
-                Bytes In:       0x%X
-                Bytes Out:      0x%X
-                Buffer Count:   0x%X
-                In Interfaces:  0x%X
-                Out Interfaces: 0x%X
-                In Handles:     0x%X
-                Out Handles:    0x%X
-                --------------------
-                """;
-        
-        out = String.format(out, procFuncAddr, cmdId, lr, vtOffset, bytesIn, bytesOut, bufferCount, inInterfaces,
-                            outInterfaces, inHandles, outHandles);
-        Msg.info(this, out);
     }
 }


### PR DESCRIPTION
i corrected the ipc emulator within ghidra-switch-loader to be able to output this:

(examples from FS exfat binary 20.0.0)

```
/* IPC INFORMATION
   Dispatch Func:     0x7100094334
   Command:           0xDB
   Command Dec:       219
   Command Name:      ChallengeCardExistence
   LR:                0x710001F1B8
   VT Offset:         0x160
   Bytes In:          0x4
   Bytes Out:         0x0
   Buffer Count:      0x3
   Buffer Attrs:      [6, 5, 5]
   Buffer Directions: [out, in, in]
   Buffer Source:     legacy-compact/u8+0xA
   In Buffers:        0x2
   Out Buffers:       0x1
   In Interfaces:     0x0
   Out Interfaces:    0x0
   In Handles:        0x0
   Out Handles:       0x0
*/
```

compared to the ninupdates reports;
 219:   {"vt": 0x160, "func": 0x7100094334, "lr": 0x710001F1B8, "inbytes":     4, "outbytes":     0, "buffers": [6, 5, 5]},


previously the ipc emulator would not correctly identify the buffer count, and did not capture the buffer directions.

i have also made the ipc information show the alias from the ipc_database.json

i have also sneaked in pseudocode labeling, related to the buffer directions, to label functions within pseudocode;

nn::fssrv::sf::IDeviceOperator::[219]ChallengeCardExistence(undefined8 *param_1,undefined8 *out_buf0,undefined8 *in_buf0,undefined8 *in_buf1, undefined8 param_5,undefined8 param_6,undefined8 param_7)

which siginificantly makes it easier for people interested in reimplenting FS much easier.

(the primary focus of testing/calibration for this has been FS, but i have tested it to do the job as well in NS for 22.1.0, though the IPC emulation process takes a bit more time now for more modern firmware exefs binaries)